### PR TITLE
エラー改善　task_path ⇨tasks_path

### DIFF
--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,7 +1,7 @@
 h1 タスクの新規登録
 
 .nav.justify-content-end
-    =link_to '一覧', task_path, class: 'nav-link'
+    =link_to '一覧', tasks_path, class: 'nav-link'
 
 = form_with model: @task, local: true do |f|
     .form-group


### PR DESCRIPTION
taskではダメな理由

config/routes.rbで　resouraces :tasks
と定義しているので、tasks出ないとpathを受け取れないから（ルーティング）