### PR TITLE
edit update作成　new editの共通化

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -12,6 +12,13 @@ class TasksController < ApplicationController
   end
 
   def edit
+    @task = Task.find(params[:id])
+  end
+
+  def update
+    task = Task.find(params[:id])
+    task.update!(task_params)
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を更新しました"
   end
 
   def create

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,8 @@
+= form_with model: task, local: true do |f|
+    .form-group
+        = f.label :name
+        = f.text_field :name, class: 'form-control', id:  'task_name'
+    .form-group
+        = f.label :description
+        = f.text_area :description, rows: 5, class: 'form-control', id: 'task-description'
+    = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,2 +1,6 @@
-h1 Tasks#edit
-p Find me in app/views/tasks/edit.html.slim
+h1 タスクの編集
+
+.nav.justify-content-end
+    =link_to '一覧', tasks_path, class: 'nav-link'
+
+= render partial: 'form', locals: { task: @task }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -8,8 +8,10 @@ table.table.table-hover
         tr
             th= Task.human_attribute_name(:name)
             th= Task.human_attribute_name(:created_at)
+            th
         tbody
             - @tasks.each do |task|
               tr
                 td= link_to task.name, task
                 td= task.created_at
+                td= link_to '編集', edit_task_path(task), class: 'btn btn-primary mr-3'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,11 +3,4 @@ h1 タスクの新規登録
 .nav.justify-content-end
     =link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-    .form-group
-        = f.label :name
-        = f.text_field :name, class: 'form-control', id:  'task_name'
-    .form-group
-        = f.label :description
-        = f.text_area :description, rows: 5, class: 'form-control', id: 'task-description'
-    = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task:@task }

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -19,3 +19,4 @@ table.table.table-hover
         tr
             th= Task.human_attribute_name(:update_at)
             td= @task.updated_at
+    = link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'


### PR DESCRIPTION
共通化＝renderメソッドのパーシャル（パーシャルテンプレート）オプション
_form.html.slimファイルを作成する。（パーシャルテンプレートファイルの先頭はアンダースコア）
フォームのコードをコピペして、モデルの@taskをtaskに変更する。
変更する理由は、localsオプションはパーシャル内のローカル変数を設定するため。
テンプレートを使用したいファイルに
= render partial: 'form', locals: { task: @task }を記述する